### PR TITLE
docs:fixed issue #168

### DIFF
--- a/image/dockerfile/onbuild.md
+++ b/image/dockerfile/onbuild.md
@@ -48,7 +48,7 @@ COPY . /app/
 
 ```Dockerfile
 FROM node:slim
-RUN "mkdir /app"
+RUN mkdir /app
 WORKDIR /app
 ONBUILD COPY ./package.json /app
 ONBUILD RUN [ "npm", "install" ]


### PR DESCRIPTION
docs:fixed issue #168
- 修改，去掉`RUN "mkdir /app"`的双引号，即：`RUN mkdir /app`
- 执行成功结果如下：
![03830c0f-7952-41dc-8bc2-481753f69c36](https://cloud.githubusercontent.com/assets/3679798/25331414/98ee6546-2915-11e7-90b7-c5ebe651ba57.png)
